### PR TITLE
[TECH-228] Remnants of TECH-224

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
       "matchPackagePatterns": [
         "^Microsoft\\.Extensions\\.",
         "^Microsoft\\.CodeAnalysis\\.",
-        "^Microsoft\\.Bcl\\.AsyncInterfaces$"
+        "^Microsoft\\.Bcl\\.AsyncInterfaces$",
+        "^System\\."
       ],
       "groupName": "Ignored NuGet dependencies",
       "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",

--- a/renovate.json
+++ b/renovate.json
@@ -19,12 +19,15 @@
   "packageRules": [
     {
       "matchManagers": ["nuget"],
-      "excludePackagePatterns": ["^Microsoft\\.Extensions\\.", "^System\\.", "^dotnet-sdk$"],
       "groupName": "NuGet dependencies"
     },
     {
       "matchManagers": ["nuget"],
-      "matchPackagePatterns": ["^Microsoft\\.Extensions\\.", "^System\\."],
+      "matchPackagePatterns": [
+        "^Microsoft\\.Extensions\\.",
+        "^Microsoft\\.CodeAnalysis\\.",
+        "^Microsoft\\.Bcl\\.AsyncInterfaces$"
+      ],
       "groupName": "Ignored NuGet dependencies",
       "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",
       "enabled": false

--- a/src/GSoft.Extensions.MediatR.Analyzers.Tests/GSoft.Extensions.MediatR.Analyzers.Tests.csproj
+++ b/src/GSoft.Extensions.MediatR.Analyzers.Tests/GSoft.Extensions.MediatR.Analyzers.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" Condition=" '$(OS)' != 'Windows_NT' " />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/GSoft.Extensions.MediatR.Analyzers.Tests/SemanticDesignAnalyzerTests.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers.Tests/SemanticDesignAnalyzerTests.cs
@@ -3,7 +3,7 @@
 public sealed class SemanticDesignAnalyzerTests : BaseAnalyzerTests<SemanticDesignAnalyzer>
 {
     [Fact]
-    public async Task Call_Mediator_Send_Method_In_Handler_Returns_One_Diagnostic()
+    public async Task Call_Mediator_Send_Or_SendAsync_Method_In_Handler_Returns_Four_Diagnostics()
     {
         const string source = @"
 public class MyQuery : IRequest<string> { }
@@ -23,14 +23,16 @@ internal class MyQueryHandler : IRequestHandler<MyQuery, string>
 
     public async Task<string> Handle(MyQuery query, CancellationToken cancellationToken)
     {
-        await this._mediator.Send(new MyOtherCommand());
-        await this._mediator.Send(new MyOtherQuery());
+        await this._mediator.Send(new MyOtherCommand(), CancellationToken.None);
+        await this._mediator.Send(new MyOtherQuery(), CancellationToken.None);
+        await this._mediator.SendAsync(new MyOtherCommand(), CancellationToken.None);
+        await this._mediator.SendAsync(new MyOtherQuery(), CancellationToken.None);
         return string.Empty;
     }
 }";
 
         var diagnostics = await this.Builder.WithSourceCode(source).Compile();
-        Assert.Equal(2, diagnostics.Length);
+        Assert.Equal(4, diagnostics.Length);
         Assert.All(diagnostics, x => Assert.Same(SemanticDesignAnalyzer.HandlersShouldNotCallHandlerRule, x.Descriptor));
     }
 
@@ -53,7 +55,8 @@ internal class MyQueryHandler : IRequestHandler<MyQuery, string>
 
     public async Task<string> Handle(MyQuery query, CancellationToken cancellationToken)
     {
-        await this._mediator.Publish(new MyNotification());
+        await this._mediator.Publish(new MyNotification(), CancellationToken.None);
+        await this._mediator.PublishAsync(new MyNotification(), CancellationToken.None);
         return string.Empty;
     }
 }";

--- a/src/GSoft.Extensions.MediatR.Analyzers/Internals/ImmutableHashSetExtensions.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/Internals/ImmutableHashSetExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Immutable;
+
+namespace GSoft.Extensions.MediatR.Analyzers.Internals;
+
+internal static class ImmutableHashSetExtensions
+{
+    // See: https://github.com/dotnet/roslyn-analyzers/blob/v3.3.4/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs#L91
+    public static void AddIfNotNull<T>(this ImmutableHashSet<T>.Builder builder, T? item)
+        where T : class
+    {
+        if (item != null)
+        {
+            builder.Add(item);
+        }
+    }
+}

--- a/src/GSoft.Extensions.MediatR.Analyzers/Internals/KnownSymbolNames.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/Internals/KnownSymbolNames.cs
@@ -5,10 +5,11 @@ internal static class KnownSymbolNames
     public const string MsExtDIAbstractionsAssembly = "Microsoft.Extensions.DependencyInjection.Abstractions";
     public const string MediatRAssembly = "MediatR";
     public const string MediatRContractsAssembly = "MediatR.Contracts";
+    public const string GSoftExtMediatRAssembly = "GSoft.Extensions.MediatR";
 
-    public const string CancellationTokenStruct = "System.Threading.CancellationToken";
     public const string ServiceCollectionInterface = "Microsoft.Extensions.DependencyInjection.IServiceCollection";
     public const string ServiceCollectionExtensionsClass = "Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions";
+    public const string GSoftMediatorExtensionsClass = "MediatR.MediatorExtensions";
 
     public const string BaseRequestInterface = "MediatR.IBaseRequest";
     public const string RequestHandlerInterfaceT1 = "MediatR.IRequestHandler`1";
@@ -28,4 +29,5 @@ internal static class KnownSymbolNames
     public const string SendMethod = "Send";
     public const string PublishMethod = "Publish";
     public const string CreateStreamMethod = "CreateStream";
+    public const string SendAsyncMethod = "SendAsync";
 }

--- a/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
@@ -88,7 +88,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
     private sealed class AnalyzerImplementation
     {
-        private readonly HashSet<INamedTypeSymbol> _requestHandlerTypes;
+        private readonly ImmutableHashSet<INamedTypeSymbol> _requestHandlerTypes;
 
         private readonly INamedTypeSymbol _baseRequestType;
         private readonly INamedTypeSymbol _notificationType;
@@ -98,23 +98,16 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
         public AnalyzerImplementation(Compilation compilation)
         {
-            this._requestHandlerTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
             this._baseRequestType = compilation.GetBestTypeByMetadataName(KnownSymbolNames.BaseRequestInterface, KnownSymbolNames.MediatRContractsAssembly)!;
             this._notificationType = compilation.GetBestTypeByMetadataName(KnownSymbolNames.NotificationInterface, KnownSymbolNames.MediatRContractsAssembly)!;
             this._notificationHandlerType = compilation.GetBestTypeByMetadataName(KnownSymbolNames.NotificationHandlerInterface, KnownSymbolNames.MediatRAssembly)!;
             this._streamRequestType = compilation.GetBestTypeByMetadataName(KnownSymbolNames.StreamRequestInterface, KnownSymbolNames.MediatRContractsAssembly)!;
             this._streamRequestHandlerType = compilation.GetBestTypeByMetadataName(KnownSymbolNames.StreamRequestHandlerInterface, KnownSymbolNames.MediatRAssembly)!;
 
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT1) is { } requestHandlerTypeT1)
-            {
-                this._requestHandlerTypes.Add(requestHandlerTypeT1);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT2) is { } requestHandlerTypeT2)
-            {
-                this._requestHandlerTypes.Add(requestHandlerTypeT2);
-            }
+            var requestHandlerTypesBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            requestHandlerTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT1, KnownSymbolNames.MediatRAssembly));
+            requestHandlerTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT2, KnownSymbolNames.MediatRAssembly));
+            this._requestHandlerTypes = requestHandlerTypesBuilder.ToImmutable();
         }
 
         public bool IsValid =>

--- a/src/GSoft.Extensions.MediatR.Analyzers/ParameterUsageAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/ParameterUsageAnalyzer.cs
@@ -72,31 +72,16 @@ public sealed class ParameterUsageAnalyzer : DiagnosticAnalyzer
             KnownSymbolNames.PublishMethod,
         };
 
-        private readonly HashSet<INamedTypeSymbol> _mediatorTypes;
+        private readonly ImmutableHashSet<INamedTypeSymbol> _mediatorTypes;
 
         public AnalyzerImplementation(Compilation compilation)
         {
-            this._mediatorTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorClass, KnownSymbolNames.MediatRAssembly) is { } mediatorType)
-            {
-                this._mediatorTypes.Add(mediatorType);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorInterface, KnownSymbolNames.MediatRAssembly) is { } mediatorInterfaceType)
-            {
-                this._mediatorTypes.Add(mediatorInterfaceType);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.SenderInterface, KnownSymbolNames.MediatRAssembly) is { } senderInterfaceType)
-            {
-                this._mediatorTypes.Add(senderInterfaceType);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.PublisherInterface, KnownSymbolNames.MediatRAssembly) is { } publisherInterfaceType)
-            {
-                this._mediatorTypes.Add(publisherInterfaceType);
-            }
+            var mediatorTypesBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            mediatorTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorClass, KnownSymbolNames.MediatRAssembly));
+            mediatorTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorInterface, KnownSymbolNames.MediatRAssembly));
+            mediatorTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.SenderInterface, KnownSymbolNames.MediatRAssembly));
+            mediatorTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.PublisherInterface, KnownSymbolNames.MediatRAssembly));
+            this._mediatorTypes = mediatorTypesBuilder.ToImmutable();
         }
 
         public bool IsValid => this._mediatorTypes.Count == 4;

--- a/src/GSoft.Extensions.MediatR.Analyzers/SemanticDesignAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/SemanticDesignAnalyzer.cs
@@ -56,43 +56,22 @@ public sealed class SemanticDesignAnalyzer : DiagnosticAnalyzer
             KnownSymbolNames.SendAsyncMethod,
         };
 
-        private readonly HashSet<INamedTypeSymbol> _mediatorTypesWithSendOrSendAsyncMethod;
-        private readonly HashSet<INamedTypeSymbol> _requestHandlerTypes;
+        private readonly ImmutableHashSet<INamedTypeSymbol> _mediatorTypesWithSendOrSendAsyncMethod;
+        private readonly ImmutableHashSet<INamedTypeSymbol> _requestHandlerTypes;
 
         public AnalyzerImplementation(Compilation compilation)
         {
-            this._mediatorTypesWithSendOrSendAsyncMethod = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-            this._requestHandlerTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var mediatorTypesWithSendOrSendAsyncMethodBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            mediatorTypesWithSendOrSendAsyncMethodBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorClass, KnownSymbolNames.MediatRAssembly));
+            mediatorTypesWithSendOrSendAsyncMethodBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorInterface, KnownSymbolNames.MediatRAssembly));
+            mediatorTypesWithSendOrSendAsyncMethodBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.SenderInterface, KnownSymbolNames.MediatRAssembly));
+            mediatorTypesWithSendOrSendAsyncMethodBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.GSoftMediatorExtensionsClass, KnownSymbolNames.GSoftExtMediatRAssembly));
+            this._mediatorTypesWithSendOrSendAsyncMethod = mediatorTypesWithSendOrSendAsyncMethodBuilder.ToImmutable();
 
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorClass, KnownSymbolNames.MediatRAssembly) is { } mediatorClassSymbol)
-            {
-                this._mediatorTypesWithSendOrSendAsyncMethod.Add(mediatorClassSymbol);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorInterface, KnownSymbolNames.MediatRAssembly) is { } mediatorInterfaceSymbol)
-            {
-                this._mediatorTypesWithSendOrSendAsyncMethod.Add(mediatorInterfaceSymbol);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.SenderInterface, KnownSymbolNames.MediatRAssembly) is { } senderInterfaceSymbol)
-            {
-                this._mediatorTypesWithSendOrSendAsyncMethod.Add(senderInterfaceSymbol);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.GSoftMediatorExtensionsClass, KnownSymbolNames.GSoftExtMediatRAssembly) is { } mediatorExtensionsSymbol)
-            {
-                this._mediatorTypesWithSendOrSendAsyncMethod.Add(mediatorExtensionsSymbol);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT1, KnownSymbolNames.MediatRAssembly) is { } requestHandlerTypeT1)
-            {
-                this._requestHandlerTypes.Add(requestHandlerTypeT1);
-            }
-
-            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT2, KnownSymbolNames.MediatRAssembly) is { } requestHandlerTypeT2)
-            {
-                this._requestHandlerTypes.Add(requestHandlerTypeT2);
-            }
+            var requestHandlerTypesBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            requestHandlerTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT1, KnownSymbolNames.MediatRAssembly));
+            requestHandlerTypesBuilder.AddIfNotNull(compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT2, KnownSymbolNames.MediatRAssembly));
+            this._requestHandlerTypes = requestHandlerTypesBuilder.ToImmutable();
         }
 
         public bool IsValid => this._mediatorTypesWithSendOrSendAsyncMethod.Count == 4 && this._requestHandlerTypes.Count == 2;

--- a/src/GSoft.Extensions.MediatR.Analyzers/SemanticDesignAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/SemanticDesignAnalyzer.cs
@@ -50,27 +50,38 @@ public sealed class SemanticDesignAnalyzer : DiagnosticAnalyzer
 
     private sealed class AnalyzerImplementation
     {
-        private readonly HashSet<INamedTypeSymbol> _mediatorTypesWithSendMethod;
+        private static readonly HashSet<string> MediatorSendAndSendAsyncMethodNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            KnownSymbolNames.SendMethod,
+            KnownSymbolNames.SendAsyncMethod,
+        };
+
+        private readonly HashSet<INamedTypeSymbol> _mediatorTypesWithSendOrSendAsyncMethod;
         private readonly HashSet<INamedTypeSymbol> _requestHandlerTypes;
 
         public AnalyzerImplementation(Compilation compilation)
         {
-            this._mediatorTypesWithSendMethod = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            this._mediatorTypesWithSendOrSendAsyncMethod = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             this._requestHandlerTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
             if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorClass, KnownSymbolNames.MediatRAssembly) is { } mediatorClassSymbol)
             {
-                this._mediatorTypesWithSendMethod.Add(mediatorClassSymbol);
+                this._mediatorTypesWithSendOrSendAsyncMethod.Add(mediatorClassSymbol);
             }
 
             if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.MediatorInterface, KnownSymbolNames.MediatRAssembly) is { } mediatorInterfaceSymbol)
             {
-                this._mediatorTypesWithSendMethod.Add(mediatorInterfaceSymbol);
+                this._mediatorTypesWithSendOrSendAsyncMethod.Add(mediatorInterfaceSymbol);
             }
 
             if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.SenderInterface, KnownSymbolNames.MediatRAssembly) is { } senderInterfaceSymbol)
             {
-                this._mediatorTypesWithSendMethod.Add(senderInterfaceSymbol);
+                this._mediatorTypesWithSendOrSendAsyncMethod.Add(senderInterfaceSymbol);
+            }
+
+            if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.GSoftMediatorExtensionsClass, KnownSymbolNames.GSoftExtMediatRAssembly) is { } mediatorExtensionsSymbol)
+            {
+                this._mediatorTypesWithSendOrSendAsyncMethod.Add(mediatorExtensionsSymbol);
             }
 
             if (compilation.GetBestTypeByMetadataName(KnownSymbolNames.RequestHandlerInterfaceT1, KnownSymbolNames.MediatRAssembly) is { } requestHandlerTypeT1)
@@ -84,7 +95,7 @@ public sealed class SemanticDesignAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        public bool IsValid => this._mediatorTypesWithSendMethod.Count == 3 && this._requestHandlerTypes.Count == 2;
+        public bool IsValid => this._mediatorTypesWithSendOrSendAsyncMethod.Count == 4 && this._requestHandlerTypes.Count == 2;
 
         public void OnBlockStartAction(OperationBlockStartAnalysisContext context)
         {
@@ -117,15 +128,15 @@ public sealed class SemanticDesignAnalyzer : DiagnosticAnalyzer
 
         private void AnalyzeOperationInvocation(OperationAnalysisContext context)
         {
-            if (context.Operation is IInvocationOperation operation && this.IsMediatorSendMethod(operation))
+            if (context.Operation is IInvocationOperation operation && this.IsMediatorSendMethodOrSendAsyncExtensionMethod(operation))
             {
                 context.ReportDiagnostic(HandlersShouldNotCallHandlerRule, operation);
             }
         }
 
-        private bool IsMediatorSendMethod(IInvocationOperation operation)
+        private bool IsMediatorSendMethodOrSendAsyncExtensionMethod(IInvocationOperation operation)
         {
-            return this._mediatorTypesWithSendMethod.Contains(operation.TargetMethod.ContainingType) && operation.TargetMethod is { Name: KnownSymbolNames.SendMethod };
+            return this._mediatorTypesWithSendOrSendAsyncMethod.Contains(operation.TargetMethod.ContainingType) && MediatorSendAndSendAsyncMethodNames.Contains(operation.TargetMethod.Name);
         }
     }
 }

--- a/src/GSoft.Extensions.MediatR.Tests/GSoft.Extensions.MediatR.Tests.csproj
+++ b/src/GSoft.Extensions.MediatR.Tests/GSoft.Extensions.MediatR.Tests.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" Condition=" '$(OS)' != 'Windows_NT' " />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Fixed: Rule `GMDTR09` "_Handlers should not call other handlers_" was not applied when using our own new "_Async_"-suffixed extension methods, added more tests
* Do what’s Microsoft is doing: Using `ImmutableHashSet<T>` in analyzers instead of `HashSet<T>`
* Ignore more Renovate dependencies update. We don’t want to upgrade some packages (`Microsoft.CodeAnalysis.*` and `BCL` async interfaces) because we want to set a _minimal_ required dependency