### PR TITLE
Reduce allocation and improve precision related to Stopwatch usage

### DIFF
--- a/src/GSoft.Extensions.MediatR/ValueStopwatch.cs
+++ b/src/GSoft.Extensions.MediatR/ValueStopwatch.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+
+namespace GSoft.Extensions.MediatR;
+
+/// <summary>
+/// Stopwatch implementation that's allocation free and better to profile/time large quantity of code
+/// </summary>
+/// <seealso cref="https://github.com/dotnet/aspnetcore/blob/main/src/Shared/ValueStopwatch/ValueStopwatch.cs"/>
+internal struct ValueStopwatch
+{
+    private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+    private readonly long _startTimestamp;
+
+    private ValueStopwatch(long startTimestamp)
+    {
+        this._startTimestamp = startTimestamp;
+    }
+
+    public bool IsActive => this._startTimestamp != 0;
+
+    public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+    public TimeSpan GetElapsedTime()
+    {
+        // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+        // So it being 0 is a clear indication of default(ValueStopwatch)
+        if (!this.IsActive)
+        {
+            throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+        }
+
+        var end = Stopwatch.GetTimestamp();
+        var timestampDelta = end - this._startTimestamp;
+        var ticks = (long)(TimestampToTicks * timestampDelta);
+        return new TimeSpan(ticks);
+    }
+}

--- a/src/GSoft.Extensions.MediatR/ValueStopwatch.cs
+++ b/src/GSoft.Extensions.MediatR/ValueStopwatch.cs
@@ -6,7 +6,7 @@ namespace GSoft.Extensions.MediatR;
 /// Stopwatch implementation that's allocation free and better to profile/time large quantity of code
 /// </summary>
 /// <seealso cref="https://github.com/dotnet/aspnetcore/blob/v7.0.0/src/Shared/ValueStopwatch/ValueStopwatch.cs"/>
-internal struct ValueStopwatch
+internal readonly struct ValueStopwatch
 {
     private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 

--- a/src/GSoft.Extensions.MediatR/ValueStopwatch.cs
+++ b/src/GSoft.Extensions.MediatR/ValueStopwatch.cs
@@ -5,7 +5,7 @@ namespace GSoft.Extensions.MediatR;
 /// <summary>
 /// Stopwatch implementation that's allocation free and better to profile/time large quantity of code
 /// </summary>
-/// <seealso cref="https://github.com/dotnet/aspnetcore/blob/main/src/Shared/ValueStopwatch/ValueStopwatch.cs"/>
+/// <seealso cref="https://github.com/dotnet/aspnetcore/blob/v7.0.0/src/Shared/ValueStopwatch/ValueStopwatch.cs"/>
 internal struct ValueStopwatch
 {
     private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;


### PR DESCRIPTION
Stopwatch.StartNew() gives a "low" precision stopwatch on some distro (Ubuntu had trouble measuring time around ~2us, it would report up to ~200us instead).

Plus, a Stopwatch occurs an allocation.

It's possible to avoid that by using Stopwatch.GetTimestamp() along with some maths (Commonly used in Microsoft's internals)

In Net 7, Stopwatch has a method `GetElapsedTime(long timestamp)` that would render the ValueStopwatch void but I think it's not currently available in this project, so I used the commonly refered ValueStop that's internal in the AspNet Code base.

References/Conversations: https://github.com/dotnet/runtime/issues/15207