### PR TITLE
TECH-321 - Add analyzer rule to allow nested handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ await mediator.SendAsync(new SayHelloCommand(null!), CancellationToken.None);
 | GMDTR10 | Design   | Warning  | Handlers should not be public                                |
 | GMDTR11 | Design   | Warning  | Use 'AddMediator' extension method instead of 'AddMediatR'   |
 | GMDTR12 | Design   | Warning  | Use method ending with 'Async' instead                       |
+| GMDTR13 | Naming   | Warning  | Name should end with 'Handler'                               |
 
 In order to change the severity of one of these diagnostic rules, use a `.editorconfig` file, for instance:
 ```ini

--- a/src/GSoft.Extensions.MediatR.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/GSoft.Extensions.MediatR.Analyzers/AnalyzerReleases.Shipped.md
@@ -16,3 +16,4 @@ GMDTR09 | Design | Warning | SemanticDesignAnalyzer, [Documentation](https://git
 GMDTR10 | Design | Warning | SemanticDesignAnalyzer, [Documentation](https://github.com/gsoft-inc/gsoft-extensions-mediatr)
 GMDTR11 | Design | Warning | ServiceRegistrationAnalyzer, [Documentation](https://github.com/gsoft-inc/gsoft-extensions-mediatr)
 GMDTR12 | Design | Warning | ParameterUsageAnalyzer, [Documentation](https://github.com/gsoft-inc/gsoft-extensions-mediatr)
+GMDTR13 | Naming | Warning | NamingConventionAnalyzer, [Documentation](https://github.com/gsoft-inc/gsoft-extensions-mediatr)

--- a/src/GSoft.Extensions.MediatR.Analyzers/Internals/RuleIdentifiers.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/Internals/RuleIdentifiers.cs
@@ -18,4 +18,5 @@ internal static class RuleIdentifiers
     public const string HandlersShouldNotBePublic = "GMDTR10";
     public const string UseAddMediatorExtensionMethod = "GMDTR11";
     public const string UseMethodEndingWithAsync = "GMDTR12";
+    public const string UseHandlerSuffix = "GMDTR13";
 }

--- a/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
@@ -168,7 +168,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var isNestedHandler = IsNestedHandler(type);
+            var isNestedHandler = IsNestedClass(type);
 
             if (!isNestedHandler && !NameEndsWithCommandHandlerOrQueryHandler(type))
             {
@@ -195,11 +195,6 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
         {
             return type.Name.EndsWith("CommandHandler", StringComparison.Ordinal) ||
                    type.Name.EndsWith("QueryHandler", StringComparison.Ordinal);
-        }
-
-        private static bool IsNestedHandler(ISymbol type)
-        {
-            return type.ContainingType?.TypeKind == TypeKind.Class;
         }
 
         private void AnalyzeStreamRequest(SymbolAnalysisContext context, ITypeSymbol type)
@@ -232,7 +227,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var isNestedHandler = IsNestedHandler(type);
+            var isNestedHandler = IsNestedClass(type);
 
             if (!isNestedHandler && !NameEndsWithStreamQueryHandler(type))
             {
@@ -285,7 +280,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var isNestedHandler = IsNestedHandler(type);
+            var isNestedHandler = IsNestedClass(type);
 
             if (!isNestedHandler && !NameEndsWithNotificationHandlerOrEventHandler(type))
             {
@@ -311,6 +306,11 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
         private static bool NameEndsWithNotificationHandlerOrEventHandler(ISymbol type)
         {
             return type.Name.EndsWith("NotificationHandler", StringComparison.Ordinal) || type.Name.EndsWith("EventHandler", StringComparison.Ordinal);
+        }
+
+        private static bool IsNestedClass(ISymbol type)
+        {
+            return type.ContainingType?.TypeKind == TypeKind.Class;
         }
     }
 }

--- a/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
@@ -170,7 +170,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
             if (IsNestedClass(type))
             {
-                if (!type.Name.EndsWith("Handler"))
+                if (!type.Name.EndsWith("Handler", StringComparison.Ordinal))
                 {
                     context.ReportDiagnostic(UseHandlerSuffixRule, type);
                 }
@@ -232,7 +232,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
             if (IsNestedClass(type))
             {
-                if (!type.Name.EndsWith("Handler"))
+                if (!type.Name.EndsWith("Handler", StringComparison.Ordinal))
                 {
                     context.ReportDiagnostic(UseHandlerSuffixRule, type);
                 }
@@ -288,7 +288,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
             if (IsNestedClass(type))
             {
-                if (!type.Name.EndsWith("Handler"))
+                if (!type.Name.EndsWith("Handler", StringComparison.Ordinal))
                 {
                     context.ReportDiagnostic(UseHandlerSuffixRule, type);
                 }

--- a/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
@@ -168,16 +168,19 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var isNestedHandler = IsNestedClass(type);
-
-            if (!isNestedHandler && !NameEndsWithCommandHandlerOrQueryHandler(type))
+            if (IsNestedClass(type))
             {
-                context.ReportDiagnostic(UseCommandHandlerOrQueryHandlerSuffixRule, type);
+                if (!type.Name.EndsWith("Handler"))
+                {
+                    context.ReportDiagnostic(UseHandlerSuffixRule, type);
+                }
             }
-
-            if (isNestedHandler && !type.Name.EndsWith("Handler"))
+            else
             {
-                context.ReportDiagnostic(UseHandlerSuffixRule, type);
+                if (!NameEndsWithCommandHandlerOrQueryHandler(type))
+                {
+                    context.ReportDiagnostic(UseCommandHandlerOrQueryHandlerSuffixRule, type);
+                }
             }
         }
 
@@ -227,16 +230,19 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var isNestedHandler = IsNestedClass(type);
-
-            if (!isNestedHandler && !NameEndsWithStreamQueryHandler(type))
+            if (IsNestedClass(type))
             {
-                context.ReportDiagnostic(UseStreamQueryHandlerSuffixRule, type);
+                if (!type.Name.EndsWith("Handler"))
+                {
+                    context.ReportDiagnostic(UseHandlerSuffixRule, type);
+                }
             }
-
-            if (isNestedHandler && !type.Name.EndsWith("Handler"))
+            else
             {
-                context.ReportDiagnostic(UseHandlerSuffixRule, type);
+                if (!NameEndsWithStreamQueryHandler(type))
+                {
+                    context.ReportDiagnostic(UseStreamQueryHandlerSuffixRule, type);
+                }
             }
         }
 
@@ -280,16 +286,19 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var isNestedHandler = IsNestedClass(type);
-
-            if (!isNestedHandler && !NameEndsWithNotificationHandlerOrEventHandler(type))
+            if (IsNestedClass(type))
             {
-                context.ReportDiagnostic(UseNotificationHandlerOrEventHandlerSuffixRule, type);
+                if (!type.Name.EndsWith("Handler"))
+                {
+                    context.ReportDiagnostic(UseHandlerSuffixRule, type);
+                }
             }
-
-            if (isNestedHandler && !type.Name.EndsWith("Handler"))
+            else
             {
-                context.ReportDiagnostic(UseHandlerSuffixRule, type);
+                if (!NameEndsWithNotificationHandlerOrEventHandler(type))
+                {
+                    context.ReportDiagnostic(UseNotificationHandlerOrEventHandlerSuffixRule, type);
+                }
             }
         }
 

--- a/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
+++ b/src/GSoft.Extensions.MediatR.Analyzers/NamingConventionAnalyzer.cs
@@ -26,6 +26,15 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: RuleIdentifiers.HelpUri);
 
+    internal static readonly DiagnosticDescriptor UseHandlerSuffixRule = new DiagnosticDescriptor(
+        id: RuleIdentifiers.UseHandlerSuffix,
+        title: "Name should end with 'Handler'",
+        messageFormat: "Name should end with 'Handler'",
+        category: RuleCategories.Naming,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: RuleIdentifiers.HelpUri);
+
     internal static readonly DiagnosticDescriptor UseStreamQuerySuffixRule = new DiagnosticDescriptor(
         id: RuleIdentifiers.UseStreamQuerySuffix,
         title: "Name should end with 'StreamQuery'",
@@ -65,6 +74,7 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
         UseCommandOrQuerySuffixRule,
         UseCommandHandlerOrQueryHandlerSuffixRule,
+        UseHandlerSuffixRule,
         UseStreamQuerySuffixRule,
         UseStreamQueryHandlerSuffixRule,
         UseNotificationOrEventSuffixRule,
@@ -153,9 +163,21 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
         private void AnalyzeRequestHandler(SymbolAnalysisContext context, ITypeSymbol type)
         {
-            if (this.ImplementsRequestHandlerInterface(type) && !NameEndsWithCommandHandlerOrQueryHandler(type))
+            if (!this.ImplementsRequestHandlerInterface(type))
+            {
+                return;
+            }
+
+            var isNestedHandler = IsNestedHandler(type);
+
+            if (!isNestedHandler && !NameEndsWithCommandHandlerOrQueryHandler(type))
             {
                 context.ReportDiagnostic(UseCommandHandlerOrQueryHandlerSuffixRule, type);
+            }
+
+            if (isNestedHandler && !type.Name.EndsWith("Handler"))
+            {
+                context.ReportDiagnostic(UseHandlerSuffixRule, type);
             }
         }
 
@@ -171,7 +193,13 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
         private static bool NameEndsWithCommandHandlerOrQueryHandler(ISymbol type)
         {
-            return type.Name.EndsWith("CommandHandler", StringComparison.Ordinal) || type.Name.EndsWith("QueryHandler", StringComparison.Ordinal);
+            return type.Name.EndsWith("CommandHandler", StringComparison.Ordinal) ||
+                   type.Name.EndsWith("QueryHandler", StringComparison.Ordinal);
+        }
+
+        private static bool IsNestedHandler(ISymbol type)
+        {
+            return type.ContainingType?.TypeKind == TypeKind.Class;
         }
 
         private void AnalyzeStreamRequest(SymbolAnalysisContext context, ITypeSymbol type)
@@ -199,9 +227,21 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
         private void AnalyzeStreamRequestHandler(SymbolAnalysisContext context, ITypeSymbol type)
         {
-            if (this.ImplementsStreamRequestHandlerInterface(type) && !NameEndsWithStreamQueryHandler(type))
+            if (!this.ImplementsStreamRequestHandlerInterface(type))
+            {
+                return;
+            }
+
+            var isNestedHandler = IsNestedHandler(type);
+
+            if (!isNestedHandler && !NameEndsWithStreamQueryHandler(type))
             {
                 context.ReportDiagnostic(UseStreamQueryHandlerSuffixRule, type);
+            }
+
+            if (isNestedHandler && !type.Name.EndsWith("Handler"))
+            {
+                context.ReportDiagnostic(UseHandlerSuffixRule, type);
             }
         }
 
@@ -240,9 +280,21 @@ public sealed class NamingConventionAnalyzer : DiagnosticAnalyzer
 
         private void AnalyzeNotificationHandler(SymbolAnalysisContext context, ITypeSymbol type)
         {
-            if (this.ImplementsNotificationHandlerInterface(type) && !NameEndsWithNotificationHandlerOrEventHandler(type))
+            if (!this.ImplementsNotificationHandlerInterface(type))
+            {
+                return;
+            }
+
+            var isNestedHandler = IsNestedHandler(type);
+
+            if (!isNestedHandler && !NameEndsWithNotificationHandlerOrEventHandler(type))
             {
                 context.ReportDiagnostic(UseNotificationHandlerOrEventHandlerSuffixRule, type);
+            }
+
+            if (isNestedHandler && !type.Name.EndsWith("Handler"))
+            {
+                context.ReportDiagnostic(UseHandlerSuffixRule, type);
             }
         }
 


### PR DESCRIPTION
I added a new rule in the case of a nested handler (defined within the command, query, etc itself). This rule only enforces that the name should end with Handler.

I tested on the analyzer performance on the project itself, on main the namingConventionAnalyzer ran in 14ms and on this branch in 22ms.