### PR TITLE
Prevent the creation of orphaned spans when using both Application Insights SDK and OpenTelemetry exporter

### DIFF
--- a/src/GSoft.Extensions.MediatR.ApplicationInsights/RequestApplicationInsightsBehavior.cs
+++ b/src/GSoft.Extensions.MediatR.ApplicationInsights/RequestApplicationInsightsBehavior.cs
@@ -22,7 +22,7 @@ internal sealed class RequestApplicationInsightsBehavior<TRequest, TResponse> : 
 
     private async Task<TResponse> HandleWithTelemetry(TRequest request, RequestHandlerDelegate<TResponse> next)
     {
-        var operation = this._telemetryClient.StartOperation<DependencyTelemetry>(request.GetType().Name);
+        var operation = this._telemetryClient.StartActivityAwareDependencyOperation(request);
 
         // Originating activity must be captured AFTER that the operation is created
         // Because ApplicationInsights SDK creates another intermediate Activity

--- a/src/GSoft.Extensions.MediatR.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/GSoft.Extensions.MediatR.ApplicationInsights/TelemetryClientExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace GSoft.Extensions.MediatR;
+
+internal static class TelemetryClientExtensions
+{
+    public static IOperationHolder<DependencyTelemetry> StartActivityAwareDependencyOperation(this TelemetryClient telemetryClient, object request)
+    {
+        if (Activity.Current is { } activity && TracingHelper.IsMediatorActivity(activity))
+        {
+            // When the current activity is our own Mediator activity created in our previous request tracing behavior,
+            // then we use it to initialize the Application Insights operation.
+            // The Application Insights SDK will take care of populating the parent-child relationship
+            // and bridge the gap between our activity, its own internal activity and the AI operation telemetry.
+            // Not doing that could cause some Application Insights AND OpenTelemetry spans to be orphans.
+            var operation = telemetryClient.StartOperation<DependencyTelemetry>(activity);
+            operation.Telemetry.Name = request.GetType().Name;
+
+            return operation;
+        }
+
+        return telemetryClient.StartOperation<DependencyTelemetry>(request.GetType().Name);
+    }
+}

--- a/src/GSoft.Extensions.MediatR/TracingHelper.cs
+++ b/src/GSoft.Extensions.MediatR/TracingHelper.cs
@@ -52,4 +52,6 @@ internal static class TracingHelper
             activity.AddTag(ExceptionStackTraceTag, ex.StackTrace);
         }
     }
+
+    public static bool IsMediatorActivity(Activity activity) => ReferenceEquals(ActivitySource, activity.Source);
 }


### PR DESCRIPTION
**Description of the issue**:

When using both Application Insights SDK and the OpenTelemetry exporter, we have:

* Application Insights SDK creates its own internal activities that are not tracked by OpenTelemetry, resulting in orphaned spans in OpenTelemetry observability vendors.

* Application Insights SDK doesn't track our own custom activities, but still it uses them as parent IDs for its own activities, also resulting in orphaned spans in Application Insights.

**Description of the fix**:

Only when using both Application Insights SDK and the OpenTelemetry exporter, use the overload of `TelemetryClient.StartOperation(...)` that accepts an activity as a parameter. When providing our own custom activity, Application Insights SDK will make sure to fix the parent-child span relationship.